### PR TITLE
Use 'close-box' appearance (less confusing) for exit-from-directions

### DIFF
--- a/app/views/layouts/_search.html.erb
+++ b/app/views/layouts/_search.html.erb
@@ -9,7 +9,7 @@
   </form>
 
   <form method="GET" action="<%= directions_path %>" class="directions_form">
-    <div width="100%" align="right"><%= link_to image_tag('search.png', :class => 'button'), root_path, { :class => "button", :title => t('site.search.close_directions_title') } %></div>
+    <div width="100%" align="right" style="height:30px"><%= link_to tag('span', { :class => "icon close"}), root_path, { :title => t('site.search.close_directions_title') } %></div>
 
     <div class="line">
       <%= image_tag "marker-green.png", :class => 'routing_marker', :id => 'marker_from', :draggable => 'true' %>


### PR DESCRIPTION
When you activate the "directions" panel, the button that takes you back to the basic search panel looks confusing. Firstly I was really unsure whether it was the button I should press to submit my routing request (wrong!) or what else it was for; secondly it looks weird at 50% width and blue and having a magnifying-glass icon in one corner.

I guess that you made it a blue button icon for "symmetry" with the blue button that activates the directions. But I think as a GUI item it has "close" semantics and a simple "x-for-close" icon is less baffling. Hence this PR for a little change of appearance for that button.