### PR TITLE
jsrouting: don't close the smallscreen header until both geocodes entered

### DIFF
--- a/app/assets/javascripts/index/directions.js.erb
+++ b/app/assets/javascripts/index/directions.js.erb
@@ -163,6 +163,7 @@ OSM.Directions = function (map) {
         d = endpoints[1].latlng;
 
     if (!o || !d) return;
+    $("header").addClass("closed");
 
     var precision = OSM.zoomPrecision(map.getZoom());
 
@@ -295,7 +296,6 @@ OSM.Directions = function (map) {
 
   $(".directions_form").on("submit", function(e) {
     e.preventDefault();
-    $("header").addClass("closed");
     getRoute();
   });
 


### PR DESCRIPTION
Fixes issue noticed by @HolgerJeromin on small-screen display: "If i enter the start point name and push enter on the soft keyboard the div with start and end is closed. I have to reopen it. When i leave the input (without enter) everything works nice." Quoted from https://github.com/openstreetmap/openstreetmap-website/pull/716#issuecomment-72515663